### PR TITLE
Authorise requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::API
+  before_action :authorize_request
+
+  def authorize_request
+    Usecase::JwtAuthentication.new(
+      auth_gateway: Gateway::Authentication.new(token_api_base_url: Rails.configuration.auth_endpoint),
+      token: request.headers['x-access-token']
+    ).execute
+  rescue Usecase::JwtAuthentication::Exception::TokenNotPresentError
+    render status: :unauthorized
+  rescue Usecase::JwtAuthentication::Exception::TokenNotValidError
+    render status: :forbidden
+  end
 end

--- a/app/lib/gateway/authentication.rb
+++ b/app/lib/gateway/authentication.rb
@@ -17,14 +17,12 @@ module Gateway
     include HTTParty
     format :json
 
-    def initialize(token_api_base_url:, service_slug:)
+    def initialize(token_api_base_url:)
       self.class.base_uri token_api_base_url
-
-      @service_slug = service_slug
     end
 
-    def hmac_secret
-      response = self.class.get("/service/#{service_slug}")
+    def hmac_secret(issuer_claim:)
+      response = self.class.get("/service/#{issuer_claim}")
       raise AuthenticationApiError, response unless response.success?
 
       response.fetch('token')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,4 +34,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.auth_endpoint = ENV.fetch('SERVICE_TOKEN_CACHE_ROOT_URL')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,5 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.auth_endpoint = ENV.fetch('SERVICE_TOKEN_CACHE_ROOT_URL')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,4 +35,6 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  #
+  config.auth_endpoint = ENV.fetch('SERVICE_TOKEN_CACHE_ROOT_URL', "example.com/#{SecureRandom.alphanumeric(5)}/")
 end

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe ApplicationController, type: :controller do
+  describe '#authorize_request requires jwt token' do
+    # test controller to test ApplicationController logic
+    controller(described_class) do
+      def create
+        render json: { allgood: true }, status: :ok
+      end
+    end
+
+    before do
+      stub_request(:get, "#{Rails.configuration.auth_endpoint}service/some_other_api").to_return(
+        status: 200,
+        body: { token: token_secret }.to_json
+      )
+    end
+
+    let(:token_secret) { 'my$ecretK3y' }
+    let(:issuer_claim) { 'some_other_api' }
+
+    let(:token) do
+      JWT.encode({ data: 'hello!' }, token_secret, 'HS256', iss: issuer_claim)
+    end
+
+    it 'rejects unauthorized when no token' do
+      post :create
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'rejects forbidden when invalid token' do
+      request.headers['x-access-token'] = 'nonsence'
+      post :create
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'ok with token' do
+      request.headers['x-access-token'] = token
+      post :create
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'runs controller method with token' do
+      request.headers['x-access-token'] = token
+      post :create
+      expect(response.body).to eq({ allgood: true }.to_json)
+    end
+  end
+end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,8 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe HealthController do
-  it 'works' do
-    get :show
-    expect(response).to be_successful
-  end
-end

--- a/spec/lib/gateway/authentication_spec.rb
+++ b/spec/lib/gateway/authentication_spec.rb
@@ -1,12 +1,8 @@
 require 'webmock/rspec'
+require 'gateway/authentication'
 
 RSpec.describe Gateway::Authentication do
-  subject(:gateway) do
-    described_class.new(
-      token_api_base_url: token_api_base_url,
-      service_slug: 'other_api'
-    )
-  end
+  subject(:gateway) { described_class.new(token_api_base_url: token_api_base_url) }
 
   before do
     WebMock.stub_request(:get, "#{token_api_base_url}/service/other_api").to_return(status: 200, body: { token: hmac_secret }.to_json)
@@ -16,24 +12,24 @@ RSpec.describe Gateway::Authentication do
   let(:hmac_secret) { SecureRandom.alphanumeric(24) }
 
   it 'can get a hmac secret' do
-    expect(gateway.hmac_secret).to eq(hmac_secret)
+    expect(gateway.hmac_secret(issuer_claim: 'other_api')).to eq(hmac_secret)
   end
 
   it 'makes a request to the service token api' do
-    gateway.hmac_secret
+    gateway.hmac_secret(issuer_claim: 'other_api')
     expect(WebMock).to have_requested(:get, "#{token_api_base_url}/service/other_api").once
   end
 
   context 'when there is a failing responce' do
     before do
-      WebMock.stub_request(:get, "#{token_api_base_url}/service/other_api").to_return(status: 500)
+      WebMock.stub_request(:get, "#{token_api_base_url}/service/failing_slug").to_return(status: 500)
     end
 
     it 'thows an error' do
       expect do
-        gateway.hmac_secret
+        gateway.hmac_secret(issuer_claim: 'failing_slug')
       end.to raise_error(Gateway::Authentication::AuthenticationApiError)
-        .with_message(%r{\[Authentication Api Error: Received 500 response from http://example.com/foo/bar/service/other_api\]})
+        .with_message(%r{\[Authentication Api Error: Received 500 response from http://example.com/foo/bar/service/failing_slug\]})
     end
   end
 end

--- a/spec/lib/usecase/jwt_authentication_spec.rb
+++ b/spec/lib/usecase/jwt_authentication_spec.rb
@@ -1,21 +1,20 @@
-require 'rails_helper'
 require 'jwt'
+require 'usecase/jwt_authentication'
+require 'gateway/authentication'
 
 RSpec.describe Usecase::JwtAuthentication do
-  subject(:usecase) { described_class.new(auth_gateway: auth_gateway) }
-
   let(:auth_gateway) { instance_spy(Gateway::Authentication) }
 
   context 'when given no token' do
     it 'nil returns an exception' do
       expect do
-        usecase.execute(token: nil)
+        described_class.new(auth_gateway: auth_gateway, token: nil).execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotPresentError)
     end
 
     it 'empty string returns an exception' do
       expect do
-        usecase.execute(token: '')
+        described_class.new(auth_gateway: auth_gateway, token: '').execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotPresentError)
     end
   end
@@ -23,7 +22,7 @@ RSpec.describe Usecase::JwtAuthentication do
   context 'when given invalid token' do
     it 'returns an exception' do
       expect do
-        usecase.execute(token: 'foo')
+        described_class.new(auth_gateway: auth_gateway, token: 'foo').execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotValidError)
     end
   end
@@ -36,19 +35,36 @@ RSpec.describe Usecase::JwtAuthentication do
     let(:hmac_secret) { SecureRandom.alphanumeric(24) }
 
     let(:jwt_token_payload) { { data: 'data', iat: Time.now.to_i } }
+    let(:jwt_token_headers) { { iss: 'some_service' } }
 
     let(:jwt_token) do
-      JWT.encode jwt_token_payload, hmac_secret, 'HS256'
+      JWT.encode jwt_token_payload, hmac_secret, 'HS256', jwt_token_headers
     end
 
-    it 'returns true' do
-      expect(usecase.execute(token: jwt_token)).to be true
+    context 'without a iat header' do
+      let(:jwt_token_headers) { {} }
+
+      it 'returns an exception' do
+        expect do
+          described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
+        end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotValidError).with_message('iss header must be present')
+      end
+    end
+
+    it 'returns if there is no problem' do
+      expect { described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute }.not_to raise_error
     end
 
     it 'gets the hmac_secret from the auth gateway' do
-      usecase.execute(token: jwt_token)
+      described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
 
       expect(auth_gateway).to have_received(:hmac_secret).once
+    end
+
+    it 'passes the Issuer Claim header to the gateway' do
+      described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
+
+      expect(auth_gateway).to have_received(:hmac_secret).with(issuer_claim: 'some_service').once
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,7 +26,7 @@ require 'rspec/rails'
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
+  # `post` in specs under `spec/request`.
   #
   # You can disable this behaviour by removing the line below, and instead
   # explicitly tag your specs with their type, e.g.:

--- a/spec/request/health_controller_spec.rb
+++ b/spec/request/health_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe HealthController, type: :request do
+  it 'can be requested' do
+    get '/health'
+    expect(response).to be_successful
+  end
+
+  it 'returns body' do
+    get '/health'
+    expect(response.body).to eq('healthy')
+  end
+end

--- a/spec/request/pdf_generator_controller_spec.rb
+++ b/spec/request/pdf_generator_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PdfGeneratorController, type: :request do
-  it 'has a placeholder url' do
+  it 'can be called' do
     post '/v1/pdf'
   end
 end


### PR DESCRIPTION
This checks for authorisation of the given request

In other apps information on who was the sender was taken from part of the URL
This implementation better follows the J.W.T. spec while making the URLs more flexible/restful