### PR TITLE
[WIP] Generate PDF with data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
           command: docker-compose run --rm app rspec
       - run:
           name: lint
-          command: docker-compose run --rm app rubocop
+          command: docker-compose run --rm app rubocop --cache false
   deploy_to_test:
     working_directory: ~/circle/git/fb-pdf-generator
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.rbc
 capybara-*.html
 .rspec
+.local
 /log
 /tmp
 /db/*.sqlite3

--- a/.local/share/pry/pry_history
+++ b/.local/share/pry/pry_history
@@ -1,0 +1,2 @@
+kit.to_file("tom.pdf")
+exit-p

--- a/.local/share/pry/pry_history
+++ b/.local/share/pry/pry_history
@@ -1,2 +1,0 @@
-kit.to_file("tom.pdf")
-exit-p

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,4 +21,4 @@ Metrics/LineLength:
   Enabled: false
 
 Metrics/BlockLength:
-  ExcludedMethods: ['describe', 'context', 'let']
+  ExcludedMethods: ['describe', 'context', 'let', 'include_context']

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG UID='1001'
 
 RUN adduser --uid ${UID}  --disabled-password --gecos "" appuser
 
+RUN chown appuser:appuser /app
+
 COPY --chown=appuser:appuser Gemfile Gemfile.lock .ruby-version ./
 
 RUN gem install bundler

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,16 +2,26 @@ class PdfsController < ActionController::Base
   include Concerns::JwtAuthentication
 
   def create
-    @submission_id = params.fetch(:submission_id)
-    @heading = params.fetch(:pdf_heading)
-    @sub_heading = params.fetch(:pdf_subheading)
-    @sections = params.fetch(:sections)
+    payload = json_hash
+    @submission_id = payload.fetch(:submission_id)
+    @heading = payload.fetch(:pdf_heading)
+    @sub_heading = payload.fetch(:pdf_subheading)
+    @sections = payload.fetch(:sections)
 
     html = render_to_string(action: 'show')
     kit = PDFKit.new(html)
     pdf = kit.to_pdf
 
-    send_data pdf, type: 'application/pdf',
-                   disposition: "attachment; filename=receipt-#{params.fetch(:submission_id)}.pdf"
+    send_data(
+      pdf,
+      type: 'application/pdf',
+      disposition: "attachment; filename=receipt-#{payload.fetch(:submission_id)}.pdf"
+    )
+  end
+
+  private
+
+  def json_hash
+    JSON.parse(request.raw_post, symbolize_names: true)
   end
 end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -9,14 +9,10 @@ class PdfsController < ActionController::Base
     @sections = payload.fetch(:sections)
 
     html = render_to_string(action: 'show')
-    kit = PDFKit.new(html)
-    pdf = kit.to_pdf
+    pdf = PDFKit.new(html).to_pdf
 
-    send_data(
-      pdf,
-      type: 'application/pdf',
-      disposition: "attachment; filename=receipt-#{payload.fetch(:submission_id)}.pdf"
-    )
+    send_data(pdf, type: 'application/pdf',
+                   disposition: "attachment; filename=receipt-#{payload.fetch(:submission_id)}.pdf")
   end
 
   private

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,6 +2,10 @@ class PdfsController < ActionController::Base
   include Concerns::JwtAuthentication
 
   def create
+    @heading = params[:pdf_heading]
+    @sub_heading = params[:pdf_subheading]
+    @sections = params[:sections]
+
     html = render_to_string(action: 'show')
     kit = PDFKit.new(html)
     pdf = kit.to_pdf

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,9 +2,10 @@ class PdfsController < ActionController::Base
   include Concerns::JwtAuthentication
 
   def create
-    @heading = params[:pdf_heading]
-    @sub_heading = params[:pdf_subheading]
-    @sections = params[:sections]
+    @submission_id = params.fetch(:submission_id)
+    @heading = params.fetch(:pdf_heading)
+    @sub_heading = params.fetch(:pdf_subheading)
+    @sections = params.fetch(:sections)
 
     html = render_to_string(action: 'show')
     kit = PDFKit.new(html)

--- a/app/views/pdfs/_footer.html.erb
+++ b/app/views/pdfs/_footer.html.erb
@@ -1,0 +1,4 @@
+<hr>
+<span class="footer">
+  <span class="submission"><%= @submission_id %></span>
+</span>

--- a/app/views/pdfs/show.html
+++ b/app/views/pdfs/show.html
@@ -1,1 +1,0 @@
-<p>Hello world</p>

--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -1,0 +1,11 @@
+<%= @sub_heading %>
+<%= @heading %>
+
+<% @sections.each do |section| %>
+  <%= section[:summary_heading] %>
+  <%= section[:heading] %>
+  
+  <% section[:questions].each do |question| %>
+    <%= question[:label] %>: <%= question[:answer] %>
+  <% end %>
+<% end %>

--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -1,11 +1,24 @@
-<%= @sub_heading %>
-<%= @heading %>
+<h2><%= @sub_heading %></h2>
+<h1><%= @heading %></h1>
 
 <% @sections.each do |section| %>
-  <%= section[:summary_heading] %>
-  <%= section[:heading] %>
-  
+  <% if section[:summary_heading] %>
+    <h2><%= section[:summary_heading] %><h2>
+    <hr>
+    <p><%= section[:heading] %></p>
+    <p></p>
+
+  <% else %>
+    <h2><%= section[:heading] %></h2>
+    <hr>
+    <p></p>
+  <% end %>
+
   <% section[:questions].each do |question| %>
-    <%= question[:label] %>: <%= question[:answer] %>
+    <p><%= question[:label] %>: <%= question[:answer] %></p>
+    <hr>
+    <p></p>
   <% end %>
 <% end %>
+
+<%= render 'pdfs/footer' %>

--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,5 +1,6 @@
 PDFKit.configure do |config|
   config.default_options = {
+    quiet: true,
     page_size: 'Legal',
     print_media_type: true
   }

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PdfsController, type: :request do
     let(:url) { '/v1/pdfs' }
 
     before do
-      post url, params: payload, headers: auth_headers
+      post url, params: payload.to_json, headers: auth_headers
     end
 
     it 'can be requested' do

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -12,7 +12,45 @@ RSpec.describe PdfsController, type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    let(:payload) { { submission_id: 'd081415b-6bc6-4aab-b6f0-607b05bd44ee' } }
+    let(:payload) do
+      {
+        submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f / Tue, 08 Oct 2019 12:44:33 GMT',
+        pdf_heading: 'Complain about a court or tribunal',
+        pdf_subheading: 'A copy of your complaint for your records',
+        sections: [
+          {
+            heading: 'What is the name you wish to appear on your certificate',
+            summary_heading: 'Your Name',
+            questions: [
+              {
+                label: 'First name',
+                answer: 'Bob'
+              },
+              {
+                label: 'Last name',
+                answer: 'Smith'
+              }
+            ]
+          }, {
+            heading: 'Contact Details',
+            summary_heading: '',
+            questions: [
+              {
+                label: 'Your email address',
+                answer: 'bob.smith@gov.uk'
+              }, {
+
+                label: 'Your complaint',
+                answer: 'tester content'
+              }, {
+                label: 'Court or tribunal your complaint is about',
+                answer: 'Aberdeen Employment Tribunal'
+              }
+            ]
+          }
+        ]
+      }
+    end
 
     it 'returns the correct Content-Type headers' do
       expect(response.headers['Content-Type']).to include('application/pdf')
@@ -26,9 +64,19 @@ RSpec.describe PdfsController, type: :request do
       expect(response.headers['Content-Disposition']).to include("attachment; filename=receipt-#{payload[:submission_id]}.pdf")
     end
 
-    it 'returns a hello world pdf' do
+    it 'includes the answers in the pdf' do
       analysis = PDF::Inspector::Text.analyze response.body
-      expect(analysis.strings.join).to include('Hello world')
+      expect(analysis.strings.join).to include('First name: Bob')
+    end
+
+    it 'includes the headers in the pdf' do
+      analysis = PDF::Inspector::Text.analyze response.body
+      expect(analysis.strings.join).to include('Complain about a court or tribunal')
+    end
+
+    it 'includes the summary heading when present' do
+      analysis = PDF::Inspector::Text.analyze response.body
+      expect(analysis.strings.join).to include('Your Name')
     end
   end
 end

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PdfsController, type: :request do
 
     let(:payload) do
       {
-        submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f / Tue, 08 Oct 2019 12:44:33 GMT',
+        submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f',
         pdf_heading: 'Complain about a court or tribunal',
         pdf_subheading: 'A copy of your complaint for your records',
         sections: [
@@ -77,6 +77,11 @@ RSpec.describe PdfsController, type: :request do
     it 'includes the summary heading when present' do
       analysis = PDF::Inspector::Text.analyze response.body
       expect(analysis.strings.join).to include('Your Name')
+    end
+
+    it 'includes the id' do
+      analysis = PDF::Inspector::Text.analyze response.body
+      expect(analysis.strings.join).to include(payload[:submission_id])
     end
   end
 end


### PR DESCRIPTION
Given the correct payload, a PDF containing all the correct data is generated.

To Do:
- [x] JSONify the request


Needs to match previous PDFs:

Without summary heading:
[without-summary-haeding.pdf](https://github.com/ministryofjustice/fb-pdf-generator/files/3712060/without-summary-haeding.pdf)

With summary heading:
[with-summary-heading.pdf](https://github.com/ministryofjustice/fb-pdf-generator/files/3712057/with-summary-heading.pdf)

next pr todos:
- [ ] font
- [ ] Styling of questions (left) and answers right. Flexbox / spans / rows
- [ ] Styling of footer
- [ ] page numbers