### PR TITLE
Don't authenticate in Development

### DIFF
--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -2,7 +2,7 @@ module JwtAuthentication
   extend ActiveSupport::Concern
 
   included do
-    before_action :authorize_request
+    before_action :authorize_request, unless: :disable_jwt?
   end
 
   def authorize_request
@@ -14,5 +14,11 @@ module JwtAuthentication
     head :unauthorized
   rescue Usecase::JwtAuthentication::Exception::TokenNotValidError
     head :forbidden
+  end
+
+  private
+
+  def disable_jwt?
+    Rails.env.development?
   end
 end


### PR DESCRIPTION
JWT authentication through the Token Service Cache is coupled to Kubernetes.

To use this app in local stack testing we need to disable JWT authentication
until the implementation can be made more generic.