### PR TITLE
Allow any host to contact this API in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.hosts.clear
 
   config.auth_endpoint = ENV.fetch('SERVICE_TOKEN_CACHE_ROOT_URL')
 end


### PR DESCRIPTION
Rails 6 has a whitelist security feature for allowed hosts.
This is unneeded in the development environment, and is blocking local stack testing.