### PR TITLE
Allow PDF Heading to be optional

### DIFF
--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -7,7 +7,7 @@ class PdfsController < ActionController::Base
     payload = json_hash
     submission_id = payload.fetch(:submission_id)
 
-    @heading = payload.fetch(:pdf_heading)
+    @heading = payload.fetch(:pdf_heading, nil)
     @sub_heading = payload.fetch(:pdf_subheading, nil)
     @sections = payload.fetch(:sections)
 

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe PdfsController, type: :request do
         }
       end
 
-      it 'subheading is optional' do
+      it 'still generates the PDF' do
         expect(response.body).to be_truthy
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe PdfsController, type: :request do
         }
       end
 
-      it 'subheading is optional' do
+      it 'still generates the PDF' do
         expect(response.body).to be_truthy
       end
     end

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe PdfsController, type: :request do
       }
     end
 
+    context 'without a heading or subheading' do
+      let(:payload) do
+        {
+          submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f',
+          sections: []
+        }
+      end
+
+      it 'subheading is optional' do
+        expect(response.body).to be_truthy
+      end
+    end
+
     context 'without a subheading' do
       let(:payload) do
         {


### PR DESCRIPTION
When the `pdf_heading:` key was missing from the payload, the application blew up.

With this change, if the key is missing it will simply not be displayed. This functionality already existed for the `pdf_subheading:`.