### PR TITLE
compatible with v2 access token

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,7 +251,7 @@ DEPENDENCIES
   wkhtmltopdf-binary (~> 0.12.5)
 
 RUBY VERSION
-   ruby 2.6.4p104
+   ruby 2.6.5p114
 
 BUNDLED WITH
    2.0.2

--- a/app/controllers/concerns/jwt_authentication.rb
+++ b/app/controllers/concerns/jwt_authentication.rb
@@ -7,12 +7,35 @@ module JwtAuthentication
 
   def authorize_request
     Usecase::JwtAuthentication.new(
-      auth_gateway: Gateway::Authentication.new(token_api_base_url: Rails.configuration.auth_endpoint),
-      token: request.headers['x-access-token']
+      auth_gateway: jwt_gateway,
+      token: jwt_token,
+      algorithm: jwt_algorithm
     ).execute
   rescue Usecase::JwtAuthentication::Exception::TokenNotPresentError
     head :unauthorized
   rescue Usecase::JwtAuthentication::Exception::TokenNotValidError
     head :forbidden
+  end
+
+  private
+
+  def jwt_gateway
+    if request.headers['x-access-token-v2']
+      Gateway::PublicKey.new
+    else
+      Gateway::Authentication.new(token_api_base_url: Rails.configuration.auth_endpoint)
+    end
+  end
+
+  def jwt_token
+    request.headers['x-access-token-v2'] || request.headers['x-access-token']
+  end
+
+  def jwt_algorithm
+    if request.headers['x-access-token-v2']
+      'RS256'
+    else
+      'HS256'
+    end
   end
 end

--- a/app/lib/gateway/authentication.rb
+++ b/app/lib/gateway/authentication.rb
@@ -1,4 +1,5 @@
 require 'httparty'
+
 module Gateway
   class Authentication
     class AuthenticationApiError < StandardError

--- a/app/lib/gateway/public_key.rb
+++ b/app/lib/gateway/public_key.rb
@@ -1,0 +1,24 @@
+require 'httparty'
+
+module Gateway
+  class PublicKey
+    include HTTParty
+
+    def initialize
+      self.class.base_uri(base_url)
+    end
+
+    def hmac_secret(issuer_claim:)
+      response = self.class.get("/service/v2/#{issuer_claim}")
+      raise StandardError, response unless response.success?
+
+      OpenSSL::PKey::RSA.new(Base64.strict_decode64(response.body))
+    end
+
+    private
+
+    def base_url
+      Rails.configuration.auth_endpoint
+    end
+  end
+end

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -46,5 +46,33 @@ RSpec.describe ApplicationController, type: :controller do
       post :create
       expect(response.body).to eq({ allgood: true }.to_json)
     end
+
+    context 'when x-access-token-v2 provided' do
+      let(:encoded_public_key) do
+        'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=='
+      end
+
+      let(:encoded_private_key) { 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM1NUQjJMZ2gwMllrdCtMcXo5bjY5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlCmx6MXh4cEpPTGV0ckxncW4zN2hNak5ZMC9uQUNjTWR1RUg5S1hycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW4KYmRtKzZzNUt2TGdVTk43WFZjZVA5UHVxWnlzeENWQTRUbm1MRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdApQYkFneFdBZmVTTGxiN0JQbHNIbS9IMEFBTCtuYmFPQ2t3dnJQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05aCnNUVlFhbzRYd2hlYnVkaGx2TWlrRVczMldLZ0t1SEhXOHpkdlU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0wKQTNZaDhMSTVHeWQ5cDZmMjdNZmxkZ1VJSFN4Y0pweTFKOEFQcXdJREFRQUJBb0lCQUU5ZjJTQVRmemlraWZ0aQp2RXRjZnlMN0EzbXRKd2c4dDI2cDcyT3czMUg0RWg4NHlOaWFHbE5ld2lialAvWW5wdmU2NitjRkg4SlBxK0NWCkJHRnhmdDBmampXZkRrZTNiTTVaUjdaQUVDaW8vay9pMEpveU5MK015ZkNRMWRmZ1FFUXV1L0gvdnJzSEdyT3cKRW5YQVZIUzg1enlCWWczbjM4QmxjVkw4V2s4R3FlMGxCUU5RSks5dSt5ckc5NEpoUTVoMTZubXlyQ0xpWkhSTAoyWS94MTdDL3BCN1VlUVFWeDZ4aVZSdVdmT1FoWlNmT2IzRHpsYldhc2owa2pTaHdWWDFQVG5sU0lxQXo5T3krClY5M013VFBtbVNOOGFiL0pGVlVBUzhtckM2elcxc0NjcFVUTFZHRVZBUFBJcWpjMmZFKzdLVGNjVDFzWkt0MWIKb2p1R2xSa0NnWUVBL2ZuK3VZcCtxSzdiQmxkUTZCSmNsNXpkR0xybXRrWFFZR096d2cvN21zd0NVdUM3UFpGYQpJV0xBSGM4QU85eDZvUFQ0SzFPNnQzYVBtMW8vUTR1S1N2NWNGK3EwaThMemVQM2JxdnowQXBXekdPVFdiMXg5CnNBRzNIOCtIT3JNS0NXVWl3bm5pUG1PMDNXUUY0dmFoWUd1WXYzSkNSNTYxanBJOFRkMkx6QmNDZ1lFQTN1ZkwKKzdqNGE2elVBOUNrak5wSnB2VkxyQk8ydUpiRHk5NXBpSzlCU3FIellQSEw3VVBWTExFaXRGWlNBWlRWRzFHMwpWbUNxMVoraXhCcTRST0t2VldyME1mSklsUlEvQXBQY3NwVXJjRTRPcnAxRkEyNjlLdXhhdnI5dmpLMCtIbWNRClEydWNRWWdUeWFXQlNZeW9laW04QWQ2UlpJRzVLQ25uTVlhNThZMENnWUVBNUp6VG5VLzlFdm5TVGJMck1QclcKUGVNRlllMWJIMWRZYW10VXM2cVBZSmVpdjlkcXM5RFN3SnFUTkVIUWhCSENrSC94bzQ2SzAvbjA2bkloNERzTApFTlpGTDRJbFltanBvRTlpSEZmMWpSNFRTS1UwSUttd3VXM1IyT0NGYVdFZjk3VUJ4T3pScWpjMTV0TFNPYXFuCk9KT2h1ekt1VnFtVjQrL2VPSGprRGFFQ2dZQUdMVFloeTRaV3RYdEtmOFdQZ1p6NDIyTTFhWFp1dHY3Rjcydk4KTmM0QlcydDdERGd5WXViTlRqcy85QVJodHRZUTQ3ckkwZlRwNW5xRUpKbG1qMEY4aEhJdjBCN2l3cVRjVld5UQpKa0lGNHFQVmd0WWV1anJUcmFqMkVDZnZKZjNLcWVCeGZkSGVudjZ0WDhDdFlSQnFFaTM3ZjBkWUdhQWYxTWxyClBlaDVJUUtCZ1FDbmN6YU8xcUx3VktyeUc4TzF5ZUhDSjQzT1h6SENwN3VnOE90aS9ScmhWZ08wSCtEdVpXUzUKSWhydHpUeU56MExyQTdibVFLTWZ4Y3k5Y29LOG9zZnVma1pZenJxM1ZFa0ViUCtjRWdLcGtlTDlaY2RSbXZ3WQozSTZkMUlOWVUwMldPSzhiRUJBNElJNGc0ak9ZcjJJUjFzb2lWZ0E2YnVya3E3QnMrUm41WFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=' }
+
+      let(:access_token) do
+        JWT.encode({ data: 'some-data' },
+                   OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)),
+                   'RS256',
+                   iss: issuer_claim)
+      end
+
+      let(:configuration) { instance_double('configuration', auth_endpoint: 'http://example.com') }
+
+      before do
+        allow(Rails).to receive(:configuration).and_return(configuration)
+        WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{issuer_claim}").to_return(status: 200, body: encoded_public_key)
+      end
+
+      it 'works' do
+        request.headers['x-access-token-v2'] = access_token
+        post :create
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 end

--- a/spec/lib/gateway/public_key_spec.rb
+++ b/spec/lib/gateway/public_key_spec.rb
@@ -1,0 +1,33 @@
+require 'webmock/rspec'
+require 'gateway/public_key'
+
+RSpec.describe Gateway::PublicKey do
+  subject(:gateway) { described_class.new }
+
+  let(:service_slug) { 'service-slug' }
+  let(:encoded_public_key) do
+    'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=='
+  end
+  let(:configuration) { instance_double('configuration', auth_endpoint: 'http://example.com') }
+
+  before do
+    allow(Rails).to receive(:configuration).and_return(configuration)
+    WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{service_slug}").to_return(status: 200, body: encoded_public_key)
+  end
+
+  it 'can get public key' do
+    expect(gateway.hmac_secret(issuer_claim: service_slug).to_pem).to eq(Base64.strict_decode64(encoded_public_key))
+  end
+
+  context 'when there is a failing responce' do
+    before do
+      WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{service_slug}").to_return(status: 500)
+    end
+
+    it 'thows an error' do
+      expect do
+        gateway.hmac_secret(issuer_claim: service_slug)
+      end.to raise_error(StandardError)
+    end
+  end
+end

--- a/spec/lib/usecase/jwt_authentication_spec.rb
+++ b/spec/lib/usecase/jwt_authentication_spec.rb
@@ -4,17 +4,18 @@ require 'gateway/authentication'
 
 RSpec.describe Usecase::JwtAuthentication do
   let(:auth_gateway) { instance_spy(Gateway::Authentication) }
+  let(:algorithm) { 'HS256' }
 
   context 'when given no token' do
     it 'nil returns an exception' do
       expect do
-        described_class.new(auth_gateway: auth_gateway, token: nil).execute
+        described_class.new(auth_gateway: auth_gateway, token: nil, algorithm: algorithm).execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotPresentError)
     end
 
     it 'empty string returns an exception' do
       expect do
-        described_class.new(auth_gateway: auth_gateway, token: '').execute
+        described_class.new(auth_gateway: auth_gateway, token: '', algorithm: algorithm).execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotPresentError)
     end
   end
@@ -22,7 +23,7 @@ RSpec.describe Usecase::JwtAuthentication do
   context 'when given invalid token' do
     it 'returns an exception' do
       expect do
-        described_class.new(auth_gateway: auth_gateway, token: 'foo').execute
+        described_class.new(auth_gateway: auth_gateway, token: 'foo', algorithm: algorithm).execute
       end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotValidError)
     end
   end
@@ -46,23 +47,23 @@ RSpec.describe Usecase::JwtAuthentication do
 
       it 'returns an exception' do
         expect do
-          described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
+          described_class.new(auth_gateway: auth_gateway, token: jwt_token, algorithm: algorithm).execute
         end.to raise_error(Usecase::JwtAuthentication::Exception::TokenNotValidError).with_message('iss header must be present')
       end
     end
 
     it 'returns if there is no problem' do
-      expect { described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute }.not_to raise_error
+      expect { described_class.new(auth_gateway: auth_gateway, token: jwt_token, algorithm: algorithm).execute }.not_to raise_error
     end
 
     it 'gets the hmac_secret from the auth gateway' do
-      described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
+      described_class.new(auth_gateway: auth_gateway, token: jwt_token, algorithm: algorithm).execute
 
       expect(auth_gateway).to have_received(:hmac_secret).once
     end
 
     it 'passes the Issuer Claim header to the gateway' do
-      described_class.new(auth_gateway: auth_gateway, token: jwt_token).execute
+      described_class.new(auth_gateway: auth_gateway, token: jwt_token, algorithm: algorithm).execute
 
       expect(auth_gateway).to have_received(:hmac_secret).with(issuer_claim: 'some_service').once
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.
-  #   config.profile_examples = 10
+  config.profile_examples = 3
   #
   #   # Run specs in random order to surface order dependencies. If you find an
   #   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
- if `access -token-v2` is provided it uses public key mechanism instead to verify jwt token