### PR TITLE
fix public key verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,15 @@ spec: docker-down docker-build test lint
 
 .PHONY: test
 test: docker-down docker-build
-	$(COMPOSE) run --rm app rspec
+	$(COMPOSE) run --rm app bundle exec rspec
 
 .PHONY: lint
 lint:
-	$(COMPOSE) run --rm app rubocop
+	$(COMPOSE) run --rm app bundle exec rubocop
 
 .PHONY: fix
 fix:
-	$(COMPOSE) run --rm app rubocop -a
+	$(COMPOSE) run --rm app bundle exec rubocop -a
 
 .PHONY: serve
 serve: docker-down docker-build

--- a/app/lib/gateway/public_key.rb
+++ b/app/lib/gateway/public_key.rb
@@ -12,7 +12,10 @@ module Gateway
       response = self.class.get("/service/v2/#{issuer_claim}")
       raise StandardError, response unless response.success?
 
-      OpenSSL::PKey::RSA.new(Base64.strict_decode64(response.body))
+      hash = JSON.parse(response.body)
+      token = hash['token']
+
+      OpenSSL::PKey::RSA.new(Base64.strict_decode64(token))
     end
 
     private

--- a/app/lib/usecase/jwt_authentication.rb
+++ b/app/lib/usecase/jwt_authentication.rb
@@ -34,7 +34,7 @@ module Usecase
     end
 
     def issuer_claim
-      @issuer_claim ||= JWT.decode(token, key = nil, verify = false).last['iss'] # rubocop:disable Lint/UselessAssignment
+      @issuer_claim ||= JWT.decode(token, key = nil, verify = false).first['iss'] # rubocop:disable Lint/UselessAssignment
     end
 
     attr_reader :auth_gateway, :token, :algorithm

--- a/spec/controller/application_controller_spec.rb
+++ b/spec/controller/application_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationController, type: :controller do
     let(:issuer_claim) { 'some_other_api' }
 
     let(:token) do
-      JWT.encode({ data: 'hello!' }, token_secret, 'HS256', iss: issuer_claim)
+      JWT.encode({ data: 'hello!', iss: issuer_claim }, token_secret, 'HS256')
     end
 
     it 'rejects unauthorized when no token' do
@@ -55,17 +55,22 @@ RSpec.describe ApplicationController, type: :controller do
       let(:encoded_private_key) { 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM1NUQjJMZ2gwMllrdCtMcXo5bjY5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlCmx6MXh4cEpPTGV0ckxncW4zN2hNak5ZMC9uQUNjTWR1RUg5S1hycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW4KYmRtKzZzNUt2TGdVTk43WFZjZVA5UHVxWnlzeENWQTRUbm1MRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdApQYkFneFdBZmVTTGxiN0JQbHNIbS9IMEFBTCtuYmFPQ2t3dnJQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05aCnNUVlFhbzRYd2hlYnVkaGx2TWlrRVczMldLZ0t1SEhXOHpkdlU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0wKQTNZaDhMSTVHeWQ5cDZmMjdNZmxkZ1VJSFN4Y0pweTFKOEFQcXdJREFRQUJBb0lCQUU5ZjJTQVRmemlraWZ0aQp2RXRjZnlMN0EzbXRKd2c4dDI2cDcyT3czMUg0RWg4NHlOaWFHbE5ld2lialAvWW5wdmU2NitjRkg4SlBxK0NWCkJHRnhmdDBmampXZkRrZTNiTTVaUjdaQUVDaW8vay9pMEpveU5MK015ZkNRMWRmZ1FFUXV1L0gvdnJzSEdyT3cKRW5YQVZIUzg1enlCWWczbjM4QmxjVkw4V2s4R3FlMGxCUU5RSks5dSt5ckc5NEpoUTVoMTZubXlyQ0xpWkhSTAoyWS94MTdDL3BCN1VlUVFWeDZ4aVZSdVdmT1FoWlNmT2IzRHpsYldhc2owa2pTaHdWWDFQVG5sU0lxQXo5T3krClY5M013VFBtbVNOOGFiL0pGVlVBUzhtckM2elcxc0NjcFVUTFZHRVZBUFBJcWpjMmZFKzdLVGNjVDFzWkt0MWIKb2p1R2xSa0NnWUVBL2ZuK3VZcCtxSzdiQmxkUTZCSmNsNXpkR0xybXRrWFFZR096d2cvN21zd0NVdUM3UFpGYQpJV0xBSGM4QU85eDZvUFQ0SzFPNnQzYVBtMW8vUTR1S1N2NWNGK3EwaThMemVQM2JxdnowQXBXekdPVFdiMXg5CnNBRzNIOCtIT3JNS0NXVWl3bm5pUG1PMDNXUUY0dmFoWUd1WXYzSkNSNTYxanBJOFRkMkx6QmNDZ1lFQTN1ZkwKKzdqNGE2elVBOUNrak5wSnB2VkxyQk8ydUpiRHk5NXBpSzlCU3FIellQSEw3VVBWTExFaXRGWlNBWlRWRzFHMwpWbUNxMVoraXhCcTRST0t2VldyME1mSklsUlEvQXBQY3NwVXJjRTRPcnAxRkEyNjlLdXhhdnI5dmpLMCtIbWNRClEydWNRWWdUeWFXQlNZeW9laW04QWQ2UlpJRzVLQ25uTVlhNThZMENnWUVBNUp6VG5VLzlFdm5TVGJMck1QclcKUGVNRlllMWJIMWRZYW10VXM2cVBZSmVpdjlkcXM5RFN3SnFUTkVIUWhCSENrSC94bzQ2SzAvbjA2bkloNERzTApFTlpGTDRJbFltanBvRTlpSEZmMWpSNFRTS1UwSUttd3VXM1IyT0NGYVdFZjk3VUJ4T3pScWpjMTV0TFNPYXFuCk9KT2h1ekt1VnFtVjQrL2VPSGprRGFFQ2dZQUdMVFloeTRaV3RYdEtmOFdQZ1p6NDIyTTFhWFp1dHY3Rjcydk4KTmM0QlcydDdERGd5WXViTlRqcy85QVJodHRZUTQ3ckkwZlRwNW5xRUpKbG1qMEY4aEhJdjBCN2l3cVRjVld5UQpKa0lGNHFQVmd0WWV1anJUcmFqMkVDZnZKZjNLcWVCeGZkSGVudjZ0WDhDdFlSQnFFaTM3ZjBkWUdhQWYxTWxyClBlaDVJUUtCZ1FDbmN6YU8xcUx3VktyeUc4TzF5ZUhDSjQzT1h6SENwN3VnOE90aS9ScmhWZ08wSCtEdVpXUzUKSWhydHpUeU56MExyQTdibVFLTWZ4Y3k5Y29LOG9zZnVma1pZenJxM1ZFa0ViUCtjRWdLcGtlTDlaY2RSbXZ3WQozSTZkMUlOWVUwMldPSzhiRUJBNElJNGc0ak9ZcjJJUjFzb2lWZ0E2YnVya3E3QnMrUm41WFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=' }
 
       let(:access_token) do
-        JWT.encode({ data: 'some-data' },
+        JWT.encode({ data: 'some-data', iss: issuer_claim },
                    OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key)),
-                   'RS256',
-                   iss: issuer_claim)
+                   'RS256')
+      end
+
+      let(:json) do
+        {
+          token: encoded_public_key
+        }.to_json
       end
 
       let(:configuration) { instance_double('configuration', auth_endpoint: 'http://example.com') }
 
       before do
         allow(Rails).to receive(:configuration).and_return(configuration)
-        WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{issuer_claim}").to_return(status: 200, body: encoded_public_key)
+        WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{issuer_claim}").to_return(status: 200, body: json)
       end
 
       it 'works' do

--- a/spec/lib/gateway/public_key_spec.rb
+++ b/spec/lib/gateway/public_key_spec.rb
@@ -10,9 +10,15 @@ RSpec.describe Gateway::PublicKey do
   end
   let(:configuration) { instance_double('configuration', auth_endpoint: 'http://example.com') }
 
+  let(:json) do
+    {
+      token: encoded_public_key
+    }.to_json
+  end
+
   before do
     allow(Rails).to receive(:configuration).and_return(configuration)
-    WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{service_slug}").to_return(status: 200, body: encoded_public_key)
+    WebMock.stub_request(:get, "#{Rails.configuration.auth_endpoint}/service/v2/#{service_slug}").to_return(status: 200, body: json)
   end
 
   it 'can get public key' do

--- a/spec/lib/usecase/jwt_authentication_spec.rb
+++ b/spec/lib/usecase/jwt_authentication_spec.rb
@@ -35,15 +35,17 @@ RSpec.describe Usecase::JwtAuthentication do
 
     let(:hmac_secret) { SecureRandom.alphanumeric(24) }
 
-    let(:jwt_token_payload) { { data: 'data', iat: Time.now.to_i } }
-    let(:jwt_token_headers) { { iss: 'some_service' } }
+    let(:jwt_token_payload) { { data: 'data', iat: Time.now.to_i, iss: 'some_service' } }
+    let(:jwt_token_headers) { {} }
 
     let(:jwt_token) do
       JWT.encode jwt_token_payload, hmac_secret, 'HS256', jwt_token_headers
     end
 
-    context 'without a iat header' do
-      let(:jwt_token_headers) { {} }
+    context 'without a iss header' do
+      before do
+        jwt_token_payload.delete(:iss)
+      end
 
       it 'returns an exception' do
         expect do

--- a/spec/shared_context/auth_tests.rb
+++ b/spec/shared_context/auth_tests.rb
@@ -1,25 +1,29 @@
 require 'webmock/rspec'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.shared_context 'when authentication required', when_authentication_required: :metadata do
   let(:url) { raise "set the url to test auth vs ie. 'let(:url) { '/v1/complaint'}' " }
 
   before do
     stub_request(:get, expected_url).to_return(
       status: 200,
-      body: { token: token_secret }.to_json
+      body: { token: encoded_public_key }.to_json
     )
   end
 
-  let(:expected_url) { "#{Rails.configuration.auth_endpoint}service/#{issuer_claim}" }
-
-  let(:token_secret) { SecureRandom.alphanumeric(10) }
-  let(:issuer_claim) { SecureRandom.alphanumeric(5)  }
-
-  let(:token) do
-    JWT.encode({ data: 'hello!' }, token_secret, 'HS256', iss: issuer_claim)
+  let(:expected_url) { "#{Rails.configuration.auth_endpoint}service/v2/#{issuer_claim}" }
+  let(:issuer_claim) { SecureRandom.alphanumeric(5) }
+  let(:encoded_private_key) { 'LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBM1NUQjJMZ2gwMllrdCtMcXo5bjY5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlCmx6MXh4cEpPTGV0ckxncW4zN2hNak5ZMC9uQUNjTWR1RUg5S1hycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW4KYmRtKzZzNUt2TGdVTk43WFZjZVA5UHVxWnlzeENWQTRUbm1MRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdApQYkFneFdBZmVTTGxiN0JQbHNIbS9IMEFBTCtuYmFPQ2t3dnJQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05aCnNUVlFhbzRYd2hlYnVkaGx2TWlrRVczMldLZ0t1SEhXOHpkdlU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0wKQTNZaDhMSTVHeWQ5cDZmMjdNZmxkZ1VJSFN4Y0pweTFKOEFQcXdJREFRQUJBb0lCQUU5ZjJTQVRmemlraWZ0aQp2RXRjZnlMN0EzbXRKd2c4dDI2cDcyT3czMUg0RWg4NHlOaWFHbE5ld2lialAvWW5wdmU2NitjRkg4SlBxK0NWCkJHRnhmdDBmampXZkRrZTNiTTVaUjdaQUVDaW8vay9pMEpveU5MK015ZkNRMWRmZ1FFUXV1L0gvdnJzSEdyT3cKRW5YQVZIUzg1enlCWWczbjM4QmxjVkw4V2s4R3FlMGxCUU5RSks5dSt5ckc5NEpoUTVoMTZubXlyQ0xpWkhSTAoyWS94MTdDL3BCN1VlUVFWeDZ4aVZSdVdmT1FoWlNmT2IzRHpsYldhc2owa2pTaHdWWDFQVG5sU0lxQXo5T3krClY5M013VFBtbVNOOGFiL0pGVlVBUzhtckM2elcxc0NjcFVUTFZHRVZBUFBJcWpjMmZFKzdLVGNjVDFzWkt0MWIKb2p1R2xSa0NnWUVBL2ZuK3VZcCtxSzdiQmxkUTZCSmNsNXpkR0xybXRrWFFZR096d2cvN21zd0NVdUM3UFpGYQpJV0xBSGM4QU85eDZvUFQ0SzFPNnQzYVBtMW8vUTR1S1N2NWNGK3EwaThMemVQM2JxdnowQXBXekdPVFdiMXg5CnNBRzNIOCtIT3JNS0NXVWl3bm5pUG1PMDNXUUY0dmFoWUd1WXYzSkNSNTYxanBJOFRkMkx6QmNDZ1lFQTN1ZkwKKzdqNGE2elVBOUNrak5wSnB2VkxyQk8ydUpiRHk5NXBpSzlCU3FIellQSEw3VVBWTExFaXRGWlNBWlRWRzFHMwpWbUNxMVoraXhCcTRST0t2VldyME1mSklsUlEvQXBQY3NwVXJjRTRPcnAxRkEyNjlLdXhhdnI5dmpLMCtIbWNRClEydWNRWWdUeWFXQlNZeW9laW04QWQ2UlpJRzVLQ25uTVlhNThZMENnWUVBNUp6VG5VLzlFdm5TVGJMck1QclcKUGVNRlllMWJIMWRZYW10VXM2cVBZSmVpdjlkcXM5RFN3SnFUTkVIUWhCSENrSC94bzQ2SzAvbjA2bkloNERzTApFTlpGTDRJbFltanBvRTlpSEZmMWpSNFRTS1UwSUttd3VXM1IyT0NGYVdFZjk3VUJ4T3pScWpjMTV0TFNPYXFuCk9KT2h1ekt1VnFtVjQrL2VPSGprRGFFQ2dZQUdMVFloeTRaV3RYdEtmOFdQZ1p6NDIyTTFhWFp1dHY3Rjcydk4KTmM0QlcydDdERGd5WXViTlRqcy85QVJodHRZUTQ3ckkwZlRwNW5xRUpKbG1qMEY4aEhJdjBCN2l3cVRjVld5UQpKa0lGNHFQVmd0WWV1anJUcmFqMkVDZnZKZjNLcWVCeGZkSGVudjZ0WDhDdFlSQnFFaTM3ZjBkWUdhQWYxTWxyClBlaDVJUUtCZ1FDbmN6YU8xcUx3VktyeUc4TzF5ZUhDSjQzT1h6SENwN3VnOE90aS9ScmhWZ08wSCtEdVpXUzUKSWhydHpUeU56MExyQTdibVFLTWZ4Y3k5Y29LOG9zZnVma1pZenJxM1ZFa0ViUCtjRWdLcGtlTDlaY2RSbXZ3WQozSTZkMUlOWVUwMldPSzhiRUJBNElJNGc0ak9ZcjJJUjFzb2lWZ0E2YnVya3E3QnMrUm41WFE9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=' }
+  let(:encoded_public_key) do
+    'LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUEzU1RCMkxnaDAyWWt0K0xxejluNgo5MlNwV0xFdXNUR1hEMGlmWTBuRHpmbXF4MWVlbHoxeHhwSk9MZXRyTGdxbjM3aE1qTlkwL25BQ2NNZHVFSDlLClhycmFieFhYVGwxeVkyMStnbVd4NDlOZVlESW5iZG0rNnM1S3ZMZ1VOTjdYVmNlUDlQdXFaeXN4Q1ZBNFRubUwKRURLZ2xTV2JVeWZ0QmVhVENKVkk2NFoxMmRNdFBiQWd4V0FmZVNMbGI3QlBsc0htL0gwQUFMK25iYU9Da3d2cgpQSkRMVFZPek9XSE1vR2dzMnJ4akJIRC9OV05ac1RWUWFvNFh3aGVidWRobHZNaWtFVzMyV0tnS3VISFc4emR2ClU4TWozM1RYK1picVhPaWtkRE54dHd2a1hGN0xBM1loOExJNUd5ZDlwNmYyN01mbGRnVUlIU3hjSnB5MUo4QVAKcXdJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg=='
   end
-
-  let(:auth_headers) { { 'x-access-token' => token } }
+  let(:private_key) do
+    OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key))
+  end
+  let(:token) do
+    JWT.encode({ data: 'hello!', iss: issuer_claim }, private_key, 'RS256')
+  end
+  let(:auth_headers) { { 'x-access-token-v2' => token } }
 
   it 'requires authentication' do
     post url
@@ -31,3 +35,4 @@ RSpec.shared_context 'when authentication required', when_authentication_require
     expect(WebMock).to have_requested(:get, expected_url).once
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
- public key is parsed from json response
- jwt from submitter now sends `iss` as part of payload not headers as described in JWT specification
- this change is backwards compatible with old auth mechanism