### PR TITLE
Add metrics adapter to the app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.6.5'
 
 gem 'httparty', '~> 0.18.0'
 gem 'jwt', '~> 2.2'
+gem 'metrics_adapter'
 gem 'pdfkit', '~> 0.8.4'
 gem 'puma', '~> 4.3'
 gem 'rails', '~> 6.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,9 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
+    keen (1.1.1)
+      addressable (~> 2.5)
+      multi_json (~> 1.12)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -94,6 +97,10 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    metrics_adapter (0.1.0)
+      activesupport
+      keen
+      mixpanel-ruby
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
@@ -101,6 +108,8 @@ GEM
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
+    mixpanel-ruby (2.2.2)
+    multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.2)
@@ -237,6 +246,7 @@ DEPENDENCIES
   httparty (~> 0.18.0)
   jwt (~> 2.2)
   listen (>= 3.0.5, < 3.3)
+  metrics_adapter
   pdf-inspector
   pdf-reader
   pdfkit (~> 0.8.4)

--- a/config/initializers/metrics_adapter.rb
+++ b/config/initializers/metrics_adapter.rb
@@ -1,0 +1,17 @@
+require 'metrics_adapter/rails'
+
+MetricsAdapter.configure do |config|
+  config.adapter = :mixpanel
+  config.adapter_options = {
+    secret: ENV['METRICS_ACCESS_KEY']
+  }
+  config.extra_attributes = { app: 'PDF Generator' }
+  config.logger = Rails.logger
+  config.trackers = %i[slow_request]
+  config.thresholds = { slow_request: 1_000 }
+
+  ## Only send metrics if is production
+  ##
+  block = -> { ENV['HOSTNAME'].to_s.include?('live-production') }
+  config.conditionals = { slow_request: block }
+end

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -51,3 +51,8 @@ spec:
               secretKeyRef:
                 name: fb-pdf-generator-api-secrets-{{ .Values.environment_name }}
                 key: sentry_dsn
+          - name: METRICS_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-pdf-generator-api-secrets-{{ .Values.environment_name }}
+                key: metrics_access_key

--- a/deploy/templates/secrets.yaml
+++ b/deploy/templates/secrets.yaml
@@ -15,3 +15,4 @@ metadata:
 type: Opaque
 data:
   token: {{ .Values.service_token }}
+  metrics_access_key: {{ .Values.metrics_access_key }}


### PR DESCRIPTION
[Trello Card](https://trello.com/c/5cXWL11V/342-request-delay-between-pages)

## Description

This PR adds the [metrics adapter gem](https://github.com/ministryofjustice/metrics-adapter) - the [first version](https://github.com/ministryofjustice/metrics-adapter/pull/1).

## Caveats

I am considering 1 second as a slow request and I added via config of the gem.

## Next PR

- [ ] Add the mixpanel secret to our git crypt repo.