### PR TITLE
Request between pages improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,7 @@ commands:
           command: |
             helm template deploy/ \
               -f /tmp/deploy-config/secrets/<< parameters.environment-name >>-secrets-values.yaml \
+              -f /tmp/deploy-config/secrets/shared-secrets-values.yaml \
               --set image_tag=<< parameters.git-tag>> \
               --set environment_name=<< parameters.environment-name >> \
               > /tmp/helm_deploy.yaml

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.6.5'
 
 gem 'httparty', '~> 0.18.0'
 gem 'jwt', '~> 2.2'
-gem 'metrics_adapter'
+gem 'metrics_adapter', '0.2.0'
 gem 'pdfkit', '~> 0.8.4'
 gem 'puma', '~> 4.3'
 gem 'rails', '~> 6.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    metrics_adapter (0.1.0)
+    metrics_adapter (0.2.0)
       activesupport
       keen
       mixpanel-ruby
@@ -246,7 +246,7 @@ DEPENDENCIES
   httparty (~> 0.18.0)
   jwt (~> 2.2)
   listen (>= 3.0.5, < 3.3)
-  metrics_adapter
+  metrics_adapter (= 0.2.0)
   pdf-inspector
   pdf-reader
   pdfkit (~> 0.8.4)

--- a/deploy/templates/secrets.yaml
+++ b/deploy/templates/secrets.yaml
@@ -6,6 +6,7 @@ type: Opaque
 data:
   secret_key_base: {{ .Values.secret_key_base }}
   sentry_dsn: {{ .Values.sentry_dsn }}
+  metrics_access_key: {{ .Values.metrics_access_key }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Two minor improvements for the request delay metrics work.

1. Add the values into the right secrets and make the shared secrets available in helm. PDF generator doesn't use our deploy scripts and inject the helm on the Circleci config.
2. Bum the metrics adapter version to accommodate improvements