### PR TITLE
Trigger acceptance tests if specs pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,11 +156,13 @@ workflows:
   version: 2
   test_and_deploy:
     jobs:
+      - test
       - trigger_acceptance_tests:
+          requires:
+            - test
           filters:
             branches:
               only: master
-      - test
       - aws-ecr/build-and-push-image:
           name: build_test_image
           account-url: AWS_ECR_ACCOUNT_URL


### PR DESCRIPTION
We do not want to trigger acceptance tests until after the spec tests have passed.