### PR TITLE
Disable pentest step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,15 +196,6 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy_to_pentest:
-          requires:
-            - test
-            - build_test_image
-          filters:
-            branches:
-              only:
-                - master
-                - deploy-to-test
       - deploy_to_test:
           requires:
             - test


### PR DESCRIPTION
We do not want to keep changing the pentest environment while testing is ongoing. We can put the step back should we need to deploy out to it.