### PR TITLE
Revert "Merge pull request #126 from ministryofjustice/dependabot/bun…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pdfkit (0.8.4.3.1)
+    pdfkit (0.8.4.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)


### PR DESCRIPTION
…dler/pdfkit-0.8.4.3.1"

The newer version is making the acceptance tests to fail. Rollback as there is card on our backlog already

This reverts commit 33524878c64573b3a50ddc0f9c1749945bd917a4, reversing
changes made to 26dcc558481264133955931091b952d99c43f6bd.