### PR TITLE
Remove fingerprint from acceptance tests step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,6 @@ jobs:
     working_directory: ~/circle/git/fb-pdf-generator
     docker: *ecr_base_image
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "b4:5d:52:af:b2:58:87:f9:ae:f3:4b:1f:32:9f:91:d7"
       - run:
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'


### PR DESCRIPTION
The fb-deploy repo is public and there are no other private repos that need to be cloned in the trigger acceptance tests step.