### PR TITLE
Run acceptance tests in their own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  aws-ecr: circleci/aws-ecr@6.3.0
-
 jobs:
   test:
     docker:
@@ -25,15 +22,15 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - add_ssh_keys:
+      - add_ssh_keys: &ssh_keys
           fingerprints:
             - "b4:5d:52:af:b2:58:87:f9:ae:f3:4b:1f:32:9f:91:d7"
-      - run:
+      - run: &base_environment_variables
           name: Setup base environment variable
           command: |
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
             echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_b45d52afb25887f9aef34b1f329f91d7" >> $BASH_ENV
-      - run:
+      - run: &deploy_scripts
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
@@ -63,17 +60,9 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - add_ssh_keys:
-          fingerprints:
-            - "b4:5d:52:af:b2:58:87:f9:ae:f3:4b:1f:32:9f:91:d7"
-      - run:
-          name: Setup base environment variable
-          command: |
-            echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
-            echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_b45d52afb25887f9aef34b1f329f91d7" >> $BASH_ENV
-      - run:
-          name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: build and push docker images
           environment:
@@ -95,15 +84,14 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
-  trigger_acceptance_tests:
-    working_directory: ~/circle/git/fb-pdf-generator
+  acceptance_tests:
     docker: *ecr_base_image
+    resource_class: large
     steps:
+      - setup_remote_docker
+      - run: *deploy_scripts
       - run:
-          name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
-      - run:
-          name: "Trigger Acceptance Tests"
+          name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
 
 workflows:
@@ -119,7 +107,7 @@ workflows:
               only:
                 - master
                 - deploy-to-test
-      - trigger_acceptance_tests:
+      - acceptance_tests:
           requires:
             - build_and_deploy_to_test
           filters:
@@ -128,7 +116,7 @@ workflows:
       - confirm_live_deploy:
           type: approval
           requires:
-            - trigger_acceptance_tests
+            - acceptance_tests
           filters:
             branches:
               only:


### PR DESCRIPTION
We no longer want to trigger the acceptance tests via the API

https://trello.com/c/BxIV1rkx/931-make-acceptance-tests-run-inside-each-deployment