### PR TITLE
Notify slack on deployment failures and successes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   test:
     docker:
@@ -12,6 +15,11 @@ jobs:
       - run:
           name: lint
           command: docker-compose run --rm app bundle exec rubocop --cache false
+      - slack/status: &slack_status
+          fail_only: true
+          only_for_branches: master
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-pdf-generator
     docker: &ecr_base_image
@@ -54,6 +62,7 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-test-production
           command: './deploy-scripts/bin/deploy'
+      - slack/status: *slack_status
   build_and_deploy_to_live:
     working_directory: ~/circle/git/fb-pdf-generator
     docker: *ecr_base_image
@@ -84,6 +93,11 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-live-production
           command: './deploy-scripts/bin/deploy'
+      - slack/status:
+          only_for_branches: master
+          success_message: ":rocket:  Successfully deployed to Live  :guitar:"
+          failure_message: ":alert:  Failed to deploy to Live  :try_not_to_cry:"
+          include_job_number_field: false
   acceptance_tests:
     docker: *ecr_base_image
     resource_class: large
@@ -93,6 +107,7 @@ jobs:
       - run:
           name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
+      - slack/status: *slack_status
 
 workflows:
   version: 2
@@ -113,6 +128,11 @@ workflows:
           filters:
             branches:
               only: master
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            - acceptance_tests
       - confirm_live_deploy:
           type: approval
           requires:


### PR DESCRIPTION
Moving the acceptance tests into each deployment has removed the notification that happens when they fail as it's not actually the circleci job that is running anymore.

We require notifications to be sent to the #form-builder-deployments channel on failure of acceptance tests.

Also on failure to deploy to production.

Also on a successful deploy to production

https://trello.com/c/myuOzEs3/933-notify-slack-when-deployments-fail-succeed