### PR TITLE
Change controller to read JSON requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   scope 'v1' do
-    resources :pdfs, only: [:create]
+    resources :pdfs, only: [:create], format: :json
   end
 
   get '/health', to: 'health#show'

--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PdfsController, type: :request do
 
     before do
       Timecop.freeze(Time.parse('2019-10-10 15:43:54 +0000'))
-      post url, params: payload.to_json, headers: auth_headers
+      post url, params: payload, headers: auth_headers, as: :json
     end
 
     after do
@@ -49,7 +49,7 @@ RSpec.describe PdfsController, type: :request do
 
                 label: 'Your complaint',
                 human_value: 'tester content',
-                answer: 'tester content'
+                answer: 'testing answer with % character'
               }, {
                 label: 'Court or tribunal your complaint is about',
                 human_value: 'Aberdeen Employment Tribunal',


### PR DESCRIPTION
Previously the controller was using www-form-urlencoded and Rails was unable to parse the params correctly. This was failing specifically when users entered a "%" character into their submissions.

Swap to use the params itself and symbolize all the param keys.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>