### PR TITLE
Allow HTML tags in PDF sub headings

### DIFF
--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :body do %>
   <% unless @sub_heading.nil? %>
-    <h2 class="subheading"><%= @sub_heading %></h2>
+    <h2 class="subheading"><%= @sub_heading.html_safe %></h2>
   <% end %>
   <h1><%= @heading %></h1>
 


### PR DESCRIPTION
We need to allow for HTML tags to be correctly parsed in the generated PDF. Previously it was printing the `<strong>` tags.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>