### PR TITLE
Revert "Allow HTML tags in PDF sub headings"

### DIFF
--- a/app/views/pdfs/show.html.erb
+++ b/app/views/pdfs/show.html.erb
@@ -7,7 +7,7 @@
 
 <% content_for :body do %>
   <% unless @sub_heading.nil? %>
-    <h2 class="subheading"><%= @sub_heading.html_safe %></h2>
+    <h2 class="subheading"><%= @sub_heading %></h2>
   <% end %>
   <h1><%= @heading %></h1>
 


### PR DESCRIPTION
Reverts ministryofjustice/fb-pdf-generator#182

We have decided not to do this for now.