### PR TITLE
Test special characters

### DIFF
--- a/spec/request/pdfs_controller_spec.rb
+++ b/spec/request/pdfs_controller_spec.rb
@@ -154,5 +154,31 @@ RSpec.describe PdfsController, type: :request do
       analysis = PDF::Inspector::Text.analyze response.body
       expect(analysis.strings.join).to include('10 Oct 2019 15:43:54 UTC')
     end
+
+    context 'with special characters' do
+      let(:payload) do
+        {
+          submission_id: '1786c427-246e-4bb7-90b9-a2e6cfae003f',
+          pdf_heading: 'Complain about a court or tribunal',
+          sections: [
+            {
+              heading: 'Contact Details',
+              questions: [
+                {
+                  label: 'Your complaint',
+                  human_value: 'My cat is named £ % ~ ! # $ & ^ * ( ) - _ = + [ ] { } | ; , . ? " < >',
+                  answer: 'testing answer with special characters'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it 'shows special characters' do
+        analysis = PDF::Inspector::Text.analyze response.body
+        expect(analysis.strings.join).to include('My cat is named £ % ~ ! # $ & ^ * ( ) - _ = + [ ] { } | ; , . ? " < >')
+      end
+    end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/ARVs1ROm/1128-add-acceptance-test-testing-special-characters

This PR adds a test to ensure special characters are accepted in submissions.