### PR TITLE
Lower sentry sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -8,7 +8,7 @@ Sentry.init do |config|
     transaction_context = sampling_context[:transaction_context]
     transaction_name = transaction_context[:name]
 
-    !transaction_name.in?(EXCLUDE_PATHS)
+    transaction_name.in?(EXCLUDE_PATHS) ? 0.0 : 0.5
   end
   config.before_send = lambda do |event, _hint|
     if event.request && event.request.data


### PR DESCRIPTION
Set sample rate to 0.5 instead of 1. Sending 100% of all events is
probably note necessary