### PR TITLE
Increase initialDelaySeconds

### DIFF
--- a/deploy/fb-pdf-generator-chart/templates/deployment.yaml
+++ b/deploy/fb-pdf-generator-chart/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
         # non-secret env vars


### PR DESCRIPTION
We are continuing to investigate networking issues across our apps
inside the Cloud Platform infrastructure. One suggestion is to increase
the initialDelaySeconds to 15 seconds which we have previously done on
the datastore app.