### PR TITLE
Lock bundler version in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN chown appuser:appuser /app
 
 COPY --chown=appuser:appuser Gemfile Gemfile.lock .ruby-version ./
 
+ENV BUNDLER_VERSION 2.1.4
 RUN gem install bundler
 
 USER appuser


### PR DESCRIPTION
The deployment was failing because the pipeline would attempt to use the latest version of bundler. Lock the bundler version to 2.1.4 to prevent this failure from occuring.

The bundler lock version step is also done in the fb-publisher Dockerfile.

Co-authored-by: Steven Leighton <steven.leighton@digital.justice.gov.uk>