### PR TITLE
GitHub key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
     docker: *ecr_base_image
     resource_class: large
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:
@@ -154,6 +155,7 @@ jobs:
   smoke_tests:
     docker: *ecr_base_image
     steps:
+      - checkout
       - setup_remote_docker: *remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
### Add 'checkout' step in circle config

Github have recently rotated their RSA SSH host key: https://github.blog/2023-03-23-we-updated-our-rsa-ssh-host-key/
As a result, the public key is no longer up to date in the `known_host` file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.

CircleCI run:
https://app.circleci.com/pipelines/github/ministryofjustice/fb-pdf-generator/1277/workflows/177e3cb2-2833-45e1-9c5f-b82e0dde7213