### PR TITLE
CDPT-3035: Remove docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - attach_workspace:
           at: .


### PR DESCRIPTION
### Circle CI pipeline failing 
`Job was rejected because this version of Docker is not supported on this resource class. Try removing the version of Docker in your .circleci/config.yml and re-running`

<img width="2271" height="873" alt="Screenshot 2025-09-08 at 14 21 50" src="https://github.com/user-attachments/assets/8ad0ed2b-e86b-4b06-b0af-a76cb38e09ac" />
<img width="2284" height="560" alt="Screenshot 2025-09-08 at 14 22 04" src="https://github.com/user-attachments/assets/0a97f624-5ed1-4f0d-b980-05f863ca7636" />
