### PR TITLE
CDPTKAN-1038: Rerun failed acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ orbs:
   slack: circleci/slack@3.4.2
   ruby: circleci/ruby@1.4.0
   aws-cli: circleci/aws-cli@4.0.0
+  browser-tools: circleci/browser-tools@1.4.8
 
 jobs:
   login-to-aws:
@@ -42,7 +43,11 @@ jobs:
       - ruby/install-deps
       - run:
           name: test
-          command: bundle exec rspec
+          command: |
+            mkdir -p ~/test-results/rspec
+            bundle exec rspec --format progress --format RspecJunitFormatter --out ~/test-results/rspec/results.xml
+      - store_test_results:
+          path: ~/test-results
       - slack/status: *slack_status
   lint:
     docker: *ruby_image
@@ -166,15 +171,55 @@ jobs:
           failure_message: ":alert:  Failed to deploy to Live Production  :try_not_to_cry:"
           include_job_number_field: false
   acceptance_tests:
-    docker: *ecr_base_image
+    docker: *ruby_image
     resource_class: large
     steps:
       - checkout
+      - run: sudo apt-get update
       - setup_remote_docker: *remote_docker
-      - run: *deploy_scripts
+      - browser-tools/install-chrome:
+          chrome-version: 149.0.7827.200
+      - browser-tools/install-chromedriver
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
+      - run: mkdir ~/rspec
       - run:
           name: Run acceptance tests
-          command: "./deploy-scripts/bin/acceptance_tests"
+          environment:
+            CI_MODE: 'true'
+          command: |
+            echo 'Cloning acceptance tests'
+            git clone https://github.com/ministryofjustice/fb-acceptance-tests
+            cd fb-acceptance-tests/integration
+            cp tests.env.ci tests.env
+
+            echo 'Setting up environment variables'
+
+            for var in \
+              GOOGLE_CLIENT_ID \
+              GOOGLE_CLIENT_SECRET \
+              GOOGLE_REFRESH_TOKEN \
+              NEW_RUNNER_ACCEPTANCE_TEST_USER \
+              NEW_RUNNER_ACCEPTANCE_TEST_PASSWORD \
+              MS_LIST_ID \
+              MS_SITE_ID \
+              MS_OAUTH_URL \
+              MS_ADMIN_APP_SECRET \
+              MS_ADMIN_APP_ID \
+              SMOKE_TEST_USER \
+              SMOKE_TEST_PASSWORD
+            do
+              printf '%s=%q\n' "$var" "${!var}" >> tests.env
+            done
+
+            bundle check || bundle install
+
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec --format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" --verbose --split-by=timings
+      - store_test_results:
+          path: ~/rspec
       - slack/status: *slack_status
   smoke_tests:
     docker: *ecr_base_image
@@ -224,6 +269,7 @@ workflows:
       - acceptance_tests:
           context: *moj-forms-context
           requires:
+            - build_and_push_image
             - deploy_to_test_dev
             - deploy_to_test_production
       - production_deploy_approval:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,6 @@ workflows:
       - acceptance_tests:
           context: *moj-forms-context
           requires:
-            - build_and_push_image
             - deploy_to_test_dev
             - deploy_to_test_production
       - production_deploy_approval:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'pry'
   gem 'pry-nav'
   gem 'pry-remote'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails', '~> 7.0.2'
   gem 'rubocop'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.7)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.87.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -339,6 +341,7 @@ DEPENDENCIES
   puma (~> 6.6.1)
   rails (~> 8.1.3)
   rspec-rails (~> 7.0.2)
+  rspec_junit_formatter
   rubocop
   rubocop-rspec
   sentry-rails (~> 5.20.0)


### PR DESCRIPTION
Configure circle CI to rerun only failed tests instead of restarting a workflow to save deployment time

JIRA: https://dsdmoj.atlassian.net/browse/CDPTKAN-1038

<img width="1084" height="438" alt="Screenshot 2026-07-07 at 13 18 25" src="https://github.com/user-attachments/assets/fcd5a7a9-621d-4883-81b5-5e3ad210472b" />
